### PR TITLE
Setup middleware hooks for base daemon mode

### DIFF
--- a/lib/setupCustomMiddlewares.js
+++ b/lib/setupCustomMiddlewares.js
@@ -17,7 +17,7 @@ function setupCustomMiddlewares(appDirectory, mainAppName, router) {
             return;
         }
 
-        // iterate through all exported router functions and execute.
+        // iterate through all exported middleware functions and execute.
         for (const middlewareFunction of exportedMiddlewareFunctions) {
             if (typeof middlewares[middlewareFunction] === 'function') {
                 console.debug('Evaluating middleware: ' + middlewareFunction);

--- a/lib/setupCustomMiddlewares.js
+++ b/lib/setupCustomMiddlewares.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const fs = require('fs');
+
+function setupCustomMiddlewares(appDirectory, mainAppName, router) {
+    const middlewareFilePath = appDirectory + '/apps/' + mainAppName + '/js/middlewares/index.js';
+
+    let middlewares;
+
+    if(fs.existsSync(middlewareFilePath)) {
+        middlewares = require(middlewareFilePath);
+
+        const exportedMiddlewareFunctions = Object.keys(middlewares);
+
+        if(exportedMiddlewareFunctions.length === 0) {
+            console.warn('A custom middlewares file was defined, but no exported functions were found. Using default amorphic middlwares');
+            return;
+        }
+
+        // iterate through all exported router functions and execute.
+        for (const middlewareFunction of exportedMiddlewareFunctions) {
+            if (typeof middlewares[middlewareFunction] === 'function') {
+                console.debug('Evaluating middleware: ' + middlewareFunction);
+                middlewares[middlewareFunction](router);
+            }
+        }
+
+        return router;
+    } else {
+        console.info('No custom middlewares found to process.');
+        return router;
+    }
+}
+
+module.exports = {
+    setupCustomMiddlewares: setupCustomMiddlewares
+};

--- a/lib/setupCustomRoutes.js
+++ b/lib/setupCustomRoutes.js
@@ -27,6 +27,9 @@ function setupCustomRoutes(appDirectory, mainAppName, router) {
         }
 
         return router;
+    } else {
+        console.info('No custom routes found to process.');
+        return router;
     }
 }
 

--- a/test/daemon/apps/daemon/js/middlewares/index.js
+++ b/test/daemon/apps/daemon/js/middlewares/index.js
@@ -4,7 +4,7 @@ let express = require('express');
 
 function exampleMiddleware(expressRouter) {
     expressRouter.use(express.json({
-        limit: '1000mb'
+        limit: '10b'
     }));
 
     return expressRouter;

--- a/test/daemon/apps/daemon/js/middlewares/index.js
+++ b/test/daemon/apps/daemon/js/middlewares/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+let express = require('express');
+
+function exampleMiddleware(expressRouter) {
+    expressRouter.use(express.json({
+        limit: '1000mb'
+    }));
+
+    return expressRouter;
+}
+
+module.exports = {
+    exampleMiddleware: exampleMiddleware
+};

--- a/test/daemon/apps/daemon/js/routers/index.js
+++ b/test/daemon/apps/daemon/js/routers/index.js
@@ -19,18 +19,14 @@ function middlewareTestEndpoint(expressRouter) {
 
 
 function testService (_req, res) {
-    res.status(200).send({
-        responseString: 'test API endpoint OK'
-    });
+    res.status(200).send('test API endpoint OK');
 }
 
 function middlewareTestService (req, res) {
     if (!req.body) {
         res.status(500).send('Error: no body');
     } else {
-        res.status(200).send({
-            responseString: 'test API endpoint OK'
-        });
+        res.status(200).send('test API endpoint OK');
     }
 }
 

--- a/test/daemon/apps/daemon/js/routers/index.js
+++ b/test/daemon/apps/daemon/js/routers/index.js
@@ -8,17 +8,34 @@ function firstEndpoint(expressRouter) {
 }
 
 function secondEndpoint(expressRouter) {
-    expressRouter.get('/test_other_endpoint', testService.bind(this));
+    expressRouter.get('/test-other-endpoint', testService.bind(this));
 
     return expressRouter;
 }
 
+function middlewareTestEndpoint(expressRouter) {
+    expressRouter.post('/middleware-endpoint', middlewareTestService.bind(this));
+}
+
 
 function testService (_req, res) {
-    res.status(200).send('test API endpoint OK');
+    res.status(200).send({
+        responseString: 'test API endpoint OK'
+    });
+}
+
+function middlewareTestService (req, res) {
+    if (!req.body) {
+        res.status(500).send('Error: no body');
+    } else {
+        res.status(200).send({
+            responseString: 'test API endpoint OK'
+        });
+    }
 }
 
 module.exports = {
     firstEndpoint: firstEndpoint,
-    secondEndpoint: secondEndpoint
+    secondEndpoint: secondEndpoint,
+    middlewareTestEndpoint: middlewareTestEndpoint
 };

--- a/test/daemon/daemon.js
+++ b/test/daemon/daemon.js
@@ -75,7 +75,7 @@ describe('Run amorphic as a deamon', function() {
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
-                assert.strictEqual(response.data.responseString, 'test API endpoint OK');
+                assert.strictEqual(response.data, 'test API endpoint OK');
             });
     });
 
@@ -84,7 +84,7 @@ describe('Run amorphic as a deamon', function() {
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
-                assert.strictEqual(response.data.responseString, 'test API endpoint OK');
+                assert.strictEqual(response.data, 'test API endpoint OK');
             });
     });
 
@@ -92,15 +92,17 @@ describe('Run amorphic as a deamon', function() {
         return axios.post('http://localhost:3001/api/middleware-endpoint', {
             firstName: 'Fred',
             lastName: 'Flintstone'
-        }).catch(function(response) {
+        })
+        .catch(function(response) {
             assert.strictEqual(response.response.status, 413, 'The response code was 413');
         });
     });
 
     it('should post to the endpoint successfully', function() {
-        return axios.post('http://localhost:3001/api/middleware-endpoint', {}).then(function(response) {
-            assert.strictEqual(response.status, 200, 'The response code was 200');
-        });
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {})
+            .then(function(response) {
+                assert.strictEqual(response.status, 200, 'The response code was 200');
+            });
     });
 
     after(function(done) {

--- a/test/daemon/daemon.js
+++ b/test/daemon/daemon.js
@@ -75,17 +75,32 @@ describe('Run amorphic as a deamon', function() {
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
-                assert.strictEqual(response.data, 'test API endpoint OK');
+                assert.strictEqual(response.data.responseString, 'test API endpoint OK');
             });
     });
 
     it('should get a response from a second custom endpoint', function() {
-        return axios.get('http://localhost:3001/api/test_other_endpoint')
+        return axios.get('http://localhost:3001/api/test-other-endpoint')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
-                assert.strictEqual(response.data, 'test API endpoint OK');
+                assert.strictEqual(response.data.responseString, 'test API endpoint OK');
             });
+    });
+
+    it('should use middleware limits to reject a POST request that\'s too large', function() {
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {
+            firstName: 'Fred',
+            lastName: 'Flintstone'
+        }).catch(function(response) {
+            assert.strictEqual(response.response.status, 413, 'The response code was 413');
+        });
+    });
+
+    it('should post to the endpoint successfully', function() {
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {}).then(function(response) {
+            assert.strictEqual(response.status, 200, 'The response code was 200');
+        });
     });
 
     after(function(done) {


### PR DESCRIPTION
Changeset: 
Create a hook to add custom middlewares. 
Test middleware application using real world scenario of limiting post payload size.
Remove JSdoc notation for plain multiline comments
Fix bug where if you didn't provide a custom route/middleware file the server was not set up at all. Fail gracefully.
Prefer dashes to underscores for multiword endpoints