### PR TITLE
HL-13810: override AmorphicSession sendToLog function when injecting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## 4.0.0
 * Enabling daemon applications to service their own endpoints.
+* Apply sendToLogFunction override to amorphic session 
 ## 3.1.0
 * Updating supertype to 3.1.0, adding a public api to allow customization of supertype's logging functionality
 ## 3.0.0

--- a/lib/listen.js
+++ b/lib/listen.js
@@ -8,6 +8,7 @@ let buildStartUpParams = require('./buildStartUpParams').buildStartUpParams;
 let logMessage = require('./utils/logger').logMessage;
 let startApplication = require('./startApplication').startApplication;
 let AmorphicServer = require('./AmorphicServer').AmorphicServer;
+let AmorphicSession = require('./utils/remoteable').AmorphicSession;
 let createServer = AmorphicServer.createServer;
 let Bluebird = require('bluebird');
 
@@ -28,6 +29,7 @@ function listen(appDirectory, sessionStore, preSessionInject, postSessionInject,
 
     if (typeof sendToLogFunction === 'function') {
         AmorphicContext.appContext.sendToLog = sendToLogFunction;
+        AmorphicSession.logger.setLogger(sendToLogFunction);
     }
 
     buildStartUpParams(configStore);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": [
-    "./lib/AmorphicServer.ts"
+    "./lib/AmorphicServer.ts",
+    "./lib/utils/remoteable.ts"
   ],
   "compilerOptions": {
     "module": "commonjs",


### PR DESCRIPTION
https://massmutual.atlassian.net/browse/HL-13810

Make sure custom logging function is applied to amorphic session  when sendToLog is overridden