### PR TITLE
Amorphic Hybrid API Mode

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 5.0.0
+* allowing amorphic session apps to set up custom endpoints
+* refactor server mode to be the source of truth for server configuration
 ## 4.6.0
 * Using stats client for persistor
 * Amorphic will now pull all minor supertype, persistor and semotus changes instead of only bug fixes

--- a/lib/AmorphicServer.ts
+++ b/lib/AmorphicServer.ts
@@ -119,7 +119,7 @@ export class AmorphicServer {
 
     /**
      *
-     * @param {e.Express} app
+     * @param {express.Express} app, an instance of an express server
      * @param {string} serverMode
      */
     constructor(app: express.Express, serverMode: string) {
@@ -285,7 +285,13 @@ export class AmorphicServer {
     }
 
     private getBaseControllerFilePath(appDirectory: string, mainAppPath: string) {
-        const codeLocation = this.serverMode === 'api' || this.serverMode === 'daemon' ? 'js' : 'public/js';
+        let codeLocation: string;
+
+        if (this.serverMode === 'api' || this.serverMode === 'daemon') {
+            codeLocation = 'js'
+        } else {
+            codeLocation = 'public/js'
+        }
         return `${appDirectory}/${mainAppPath}/${codeLocation}/`;
     }
 }

--- a/lib/AmorphicServer.ts
+++ b/lib/AmorphicServer.ts
@@ -74,8 +74,7 @@ export class AmorphicServer {
 
         const serverOptions: ServerOptions = appConfig.appConfig && appConfig.appConfig.serverOptions;
 
-        // serverMode is only set to 'api' right now, 
-        // we will need to revisit when we want to deprecate isDaemon
+        // const apiPath = (serverOptions && serverOptions.apiPath) ? serverOptions.apiPath : '/';
 
         // if we are strictly setting up user endpoints only. no default amorphic routes.
         if (server.serverMode === 'api') {
@@ -85,8 +84,7 @@ export class AmorphicServer {
             if (postSessionInject) {
                 postSessionInject.call(null, server.app);
             }
-            const apiPath = (serverOptions && serverOptions.apiPath) ? serverOptions.apiPath : '/';
-            server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
+            server.setupUserEndpoints(appDirectory, appList[mainApp]);
         }
         else { // we are setting up both amorphic default endpoints, and user defined endpoints.
             server.setupAmorphicRouter(amorphicRouterOptions);

--- a/lib/AmorphicServer.ts
+++ b/lib/AmorphicServer.ts
@@ -44,7 +44,7 @@ type ServerOptions = https.ServerOptions &
 //@TODO: Experiment with app.engine so we can have customizable SSR
 export class AmorphicServer {
     app: express.Express;
-
+    private serverMode: string;
     routers: { path: string; router: express.Router }[] = [];
 
     /**
@@ -57,10 +57,10 @@ export class AmorphicServer {
     * @param sessionConfig - Object containing the session config
     */
     static createServer(preSessionInject, postSessionInject, appList, appStartList, appDirectory, sessionConfig) {
-        const server = new AmorphicServer(express());
         const amorphicOptions = AmorphicContext.amorphicOptions;
         const mainApp = amorphicOptions.mainApp;
         const appConfig = AmorphicContext.applicationConfig[mainApp];
+        const server = new AmorphicServer(express(), appConfig.appConfig.serverMode);
 
         const amorphicRouterOptions: Options = {
             amorphicOptions,
@@ -73,12 +73,12 @@ export class AmorphicServer {
         };
 
         const serverOptions: ServerOptions = appConfig.appConfig && appConfig.appConfig.serverOptions;
-        //
+
         // serverMode is only set to 'api' right now, 
         // we will need to revisit when we want to deprecate isDaemon
 
-        // Setup the preSession and postSession Injects for daemon mode only (if only daemon mode)
-        if (appConfig.appConfig.serverMode === 'api') {
+        // if we are strictly setting up user endpoints only. no default amorphic routes.
+        if (server.serverMode === 'api') {
             if (preSessionInject) {
                 preSessionInject.call(null, server.app);
             }
@@ -88,15 +88,9 @@ export class AmorphicServer {
             const apiPath = (serverOptions && serverOptions.apiPath) ? serverOptions.apiPath : '/';
             server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
         }
-
-        // Setup the amorphic router if not daemon Only
-        else {
+        else { // we are setting up both amorphic default endpoints, and user defined endpoints.
             server.setupAmorphicRouter(amorphicRouterOptions);
-            // Setup the daemon mode router if this field is set at all
-
-            if (appConfig.appConfig.isDaemon) {
-                server.setupUserEndpoints(appDirectory, appList[mainApp]);
-            }
+            server.setupUserEndpoints(appDirectory, appList[mainApp]);
         }
 
         server.app.locals.name = mainApp;
@@ -134,12 +128,13 @@ export class AmorphicServer {
     }
 
     /**
-    * @TODO: make this a proper class
-    *
-    * @param {express.Express} app Express server
-    **/
-    constructor(app: express.Express) {
+     *
+     * @param {e.Express} app
+     * @param {string} serverMode
+     */
+    constructor(app: express.Express, serverMode: string) {
         this.app = app;
+        this.serverMode = serverMode;
     }
 
     /**
@@ -288,22 +283,19 @@ export class AmorphicServer {
      * for amorphic is for the '/amorphic' routes to run
      * @memberof AmorphicServer
      */
-    setupUserEndpoints(appDirectory, mainAppPath, apiPath = '/api') {
-
-        let router = setupCustomMiddlewares(appDirectory, mainAppPath, express.Router());
-        router = setupCustomRoutes(appDirectory, mainAppPath, router);
+    setupUserEndpoints(appDirectory: string, mainAppPath: string, apiPath = '/api') {
+        let filePath = this.getBaseControllerFilePath(appDirectory, mainAppPath);
+        let router = setupCustomMiddlewares(filePath, express.Router());
+        router = setupCustomRoutes(filePath, router);
 
         if (router) {
             this.app.use(apiPath, router);
             this.routers.push({ path: apiPath, router: router });
         }
-
-        /**
-        *   
-        * Keep in mind when registering the middlewares be careful!
-        * @TODO: when implementing middlewares register error handling from middlewares on APP not ROUTER 
-        * https://github.com/expressjs/express/issues/2679
-        */
     }
 
+    private getBaseControllerFilePath(appDirectory: string, mainAppPath: string) {
+        const codeLocation = this.serverMode === 'api' || this.serverMode === 'daemon' ? 'js' : 'public/js';
+        return `${appDirectory}/${mainAppPath}/${codeLocation}/`;
+    }
 }

--- a/lib/AmorphicServer.ts
+++ b/lib/AmorphicServer.ts
@@ -76,19 +76,11 @@ export class AmorphicServer {
 
         const apiPath = serverOptions && serverOptions.apiPath;
 
-        // if we are strictly setting up user endpoints only. no default amorphic routes.
-        if (server.serverMode === 'api') {
-            if (preSessionInject) {
-                preSessionInject.call(null, server.app);
-            }
-            if (postSessionInject) {
-                postSessionInject.call(null, server.app);
-            }
-            server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
-        }
-        else { // we are setting up both amorphic default endpoints, and user defined endpoints.
+        server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
+
+        // for anything other than user only routes, set up our default amorphic router.
+        if (server.serverMode !== 'api') {
             server.setupAmorphicRouter(amorphicRouterOptions);
-            server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
         }
 
         server.app.locals.name = mainApp;

--- a/lib/AmorphicServer.ts
+++ b/lib/AmorphicServer.ts
@@ -74,7 +74,7 @@ export class AmorphicServer {
 
         const serverOptions: ServerOptions = appConfig.appConfig && appConfig.appConfig.serverOptions;
 
-        // const apiPath = (serverOptions && serverOptions.apiPath) ? serverOptions.apiPath : '/';
+        const apiPath = serverOptions && serverOptions.apiPath;
 
         // if we are strictly setting up user endpoints only. no default amorphic routes.
         if (server.serverMode === 'api') {
@@ -84,11 +84,11 @@ export class AmorphicServer {
             if (postSessionInject) {
                 postSessionInject.call(null, server.app);
             }
-            server.setupUserEndpoints(appDirectory, appList[mainApp]);
+            server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
         }
         else { // we are setting up both amorphic default endpoints, and user defined endpoints.
             server.setupAmorphicRouter(amorphicRouterOptions);
-            server.setupUserEndpoints(appDirectory, appList[mainApp]);
+            server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
         }
 
         server.app.locals.name = mainApp;

--- a/lib/getTemplates.js
+++ b/lib/getTemplates.js
@@ -174,7 +174,7 @@ function getTemplates(persistObjectTemplate, appPath, templates, config, appName
 
     // Because of the two pass nature, requiredTemplates are not update for extends which are only done between passes
     // Record source and source map
-    if (ast && !applicationSource[appName] && !(config.appConfig.isDaemon || config.appConfig.serverMode === 'api')) {
+    if (ast && !applicationSource[appName] && !(config.appConfig.serverMode === 'daemon' || config.appConfig.serverMode === 'api')) {
         ast.figure_out_scope();
 
         /*eslint-disable new-cap, camelcase */

--- a/lib/setupCustomMiddlewares.js
+++ b/lib/setupCustomMiddlewares.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs');
 
-function setupCustomMiddlewares(appDirectory, mainAppPath, router) {
-    const middlewareFilePath = `${appDirectory}/${mainAppPath}/js/middlewares/index.js`;
+function setupCustomMiddlewares(filePath, router) {
+    const middlewareFilePath = `${filePath}/middlewares/index.js`;
 
     let middlewares;
 

--- a/lib/setupCustomRoutes.js
+++ b/lib/setupCustomRoutes.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs');
 
-function setupCustomRoutes(appDirectory, mainAppPath, router) {
-    const routerFilePath = `${appDirectory}/${mainAppPath}/js/routers/index.js`;
+function setupCustomRoutes(filePath, router) {
+    const routerFilePath = `${filePath}/routers/index.js`;
 
     let routers;
 

--- a/lib/startApplication.js
+++ b/lib/startApplication.js
@@ -31,7 +31,7 @@ function startApplication(appName, appDirectory, appList, configStore, sessionSt
     let commonJsDir = commonPath + '/js/';
     let controllerJsDir = path + '/public/js/';
 
-    if (config.isDaemon || config.serverMode === 'api') {
+    if (config.serverMode === 'daemon' || config.serverMode === 'api') {
         controllerJsDir = path + '/js/';
     }
 
@@ -326,7 +326,7 @@ function checkTypes(classes) {
  */
 function buildBaseTemplate(appConfig, processTypescript) {
     const config = appConfig.appConfig;
-    if (config && (config.isDaemon || config.serverMode === 'api')) {
+    if (config && (config.serverMode === 'daemon' || config.serverMode === 'api')) {
         return persistor(null, null, superType);
     }
 
@@ -350,7 +350,7 @@ function buildBaseTemplate(appConfig, processTypescript) {
  * @param {Object} appTemplates - unknown
  */
 function finishDaemonIfNeeded(config, prop, prefix, appName, baseTemplate, appTemplates) {
-	if (config.isDaemon || config.serverMode === 'api') {
+	if (config.serverMode === 'daemon' || config.serverMode === 'api') {
 		let ControllerTemplate = AmorphicContext.applicationTSController[appName] ||
 			appTemplates[prop].Controller;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amorphic",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/haven-life/amorphic",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "dependencies": {
     "@havenlife/persistor": "3.x",
     "@havenlife/semotus": "3.x",

--- a/test/daemon/apps/daemon/config.json
+++ b/test/daemon/apps/daemon/config.json
@@ -1,5 +1,5 @@
 {
-  "isDaemon": "true",
+  "serverMode": "daemon",
   "createControllerFor": "#",
   "ver":          "0",
   "modules":      {},

--- a/test/daemon_auto/apps/daemon_auto/config.json
+++ b/test/daemon_auto/apps/daemon_auto/config.json
@@ -1,5 +1,5 @@
 {
-  "isDaemon": "true",
+  "serverMode": "daemon",
   "createControllerFor": "#",
   "ver":          "0",
   "modules":      {},

--- a/test/daemon_only/daemon.js
+++ b/test/daemon_only/daemon.js
@@ -40,7 +40,7 @@ describe('Run amorphic as deamon only', function() {
 
 
     it('should get an 200 response from a custom GET endpoint', function() {
-        return axios.get('http://localhost:3001/test')
+        return axios.get('http://localhost:3001/api/test')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -49,7 +49,7 @@ describe('Run amorphic as deamon only', function() {
     });
 
     it('should get a response from a second custom endpoint', function() {
-        return axios.get('http://localhost:3001/test-other-endpoint')
+        return axios.get('http://localhost:3001/api/test-other-endpoint')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -58,7 +58,7 @@ describe('Run amorphic as deamon only', function() {
     });
 
     it('should use middleware limits to reject a POST request that\'s too large', function() {
-        return axios.post('http://localhost:3001/middleware-endpoint', {
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {
             firstName: 'Fred',
             lastName: 'Flintstone'
         })
@@ -68,7 +68,7 @@ describe('Run amorphic as deamon only', function() {
     });
 
     it('should post to the endpoint successfully', function() {
-        return axios.post('http://localhost:3001/middleware-endpoint', {})
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {})
             .then(function(response) {
                 assert.strictEqual(response.status, 200, 'The response code was 200');
             });
@@ -76,7 +76,7 @@ describe('Run amorphic as deamon only', function() {
 
     // Amorphic xhr tests
     it('should error out because amorphic/xhr cannot be reached', function() {
-        return axios.get('http://localhost:3001/amorphic/xhr')
+        return axios.get('http://localhost:3001/api/amorphic/xhr')
             .then(function() {
                 assert.isNotOk('To be here');
             })

--- a/test/daemon_only_apiPath/apps/daemon_only_apiPath/config.json
+++ b/test/daemon_only_apiPath/apps/daemon_only_apiPath/config.json
@@ -10,6 +10,6 @@
   "dbUser": "postgres",
   "dbPassword": "postgres",
   "serverOptions": {
-    "apiPath": "/special-path"
+    "apiPath": "/"
   }
 }

--- a/test/daemon_only_apiPath/apps/daemon_only_apiPath/config.json
+++ b/test/daemon_only_apiPath/apps/daemon_only_apiPath/config.json
@@ -10,6 +10,6 @@
   "dbUser": "postgres",
   "dbPassword": "postgres",
   "serverOptions": {
-    "apiPath": "/api"
+    "apiPath": "/special-path"
   }
 }

--- a/test/daemon_only_apiPath/daemon.js
+++ b/test/daemon_only_apiPath/daemon.js
@@ -40,7 +40,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
 
 
     it('should get an 200 response from a custom GET endpoint', function() {
-        return axios.get('http://localhost:3001/api/test')
+        return axios.get('http://localhost:3001/special-path/test')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -49,7 +49,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should get a response from a second custom endpoint', function() {
-        return axios.get('http://localhost:3001/api/test-other-endpoint')
+        return axios.get('http://localhost:3001/special-path/test-other-endpoint')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -58,7 +58,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should use middleware limits to reject a POST request that\'s too large', function() {
-        return axios.post('http://localhost:3001/api/middleware-endpoint', {
+        return axios.post('http://localhost:3001/special-path/middleware-endpoint', {
             firstName: 'Fred',
             lastName: 'Flintstone'
         })
@@ -68,7 +68,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should post to the endpoint successfully', function() {
-        return axios.post('http://localhost:3001/api/middleware-endpoint', {})
+        return axios.post('http://localhost:3001/special-path/middleware-endpoint', {})
             .then(function(response) {
                 assert.strictEqual(response.status, 200, 'The response code was 200');
             });

--- a/test/daemon_only_apiPath/daemon.js
+++ b/test/daemon_only_apiPath/daemon.js
@@ -40,7 +40,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
 
 
     it('should get an 200 response from a custom GET endpoint', function() {
-        return axios.get('http://localhost:3001/special-path/test')
+        return axios.get('http://localhost:3001/test')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -49,7 +49,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should get a response from a second custom endpoint', function() {
-        return axios.get('http://localhost:3001/special-path/test-other-endpoint')
+        return axios.get('http://localhost:3001/test-other-endpoint')
             .then(function(response) {
                 assert.isOk(response, 'The response is ok');
                 assert.strictEqual(response.status, 200, 'The response code was 200');
@@ -58,7 +58,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should use middleware limits to reject a POST request that\'s too large', function() {
-        return axios.post('http://localhost:3001/special-path/middleware-endpoint', {
+        return axios.post('http://localhost:3001/middleware-endpoint', {
             firstName: 'Fred',
             lastName: 'Flintstone'
         })
@@ -68,7 +68,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should post to the endpoint successfully', function() {
-        return axios.post('http://localhost:3001/special-path/middleware-endpoint', {})
+        return axios.post('http://localhost:3001/middleware-endpoint', {})
             .then(function(response) {
                 assert.strictEqual(response.status, 200, 'The response code was 200');
             });

--- a/test/daemon_secure/apps/daemon_secure/config.json
+++ b/test/daemon_secure/apps/daemon_secure/config.json
@@ -1,5 +1,5 @@
 {
-  "isDaemon": "true",
+  "serverMode": "daemon",
   "createControllerFor": "#",
   "ver":          "0",
   "modules":      {},

--- a/test/postgres/amorphic.js
+++ b/test/postgres/amorphic.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+let assert = require('chai').assert;
 var request = require('request');
 var axios = require('axios');
 var path = require('path');
@@ -751,6 +752,50 @@ describe('statsd module enabled', function () {
     it('should be able to consume a module and put it on amorphic static (supertype session)', () => {
         const statsdClient = SupertypeSession.amorphicStatic.statsdClient;
         expect(statsdClient.timing).to.equal('timing stub');
+    });
+});
+
+describe('amorphic api enabled', function () {
+
+    before(function (done) {
+        return beforeEachDescribe(done, 'test', 'yes', 'prod');
+    });
+
+    after(afterEachDescribe);
+
+    it('should get an 200 response from a custom GET endpoint', function () {
+        return axios.get('http://localhost:3001/api/test')
+            .then(function (response) {
+                assert.isOk(response, 'The response is ok');
+                assert.strictEqual(response.status, 200, 'The response code was 200');
+                assert.strictEqual(response.data, 'test API endpoint OK');
+            });
+    });
+
+    it('should get a response from a second custom endpoint', function () {
+        return axios.get('http://localhost:3001/api/test-other-endpoint')
+            .then(function (response) {
+                assert.isOk(response, 'The response is ok');
+                assert.strictEqual(response.status, 200, 'The response code was 200');
+                assert.strictEqual(response.data, 'test API endpoint OK');
+            });
+    });
+
+    it('should use middleware limits to reject a POST request that\'s too large', function () {
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {
+            firstName: 'Fred',
+            lastName: 'Flintstone'
+        })
+            .catch(function (response) {
+                assert.strictEqual(response.response.status, 413, 'The response code was 413');
+            });
+    });
+
+    it('should post to the endpoint successfully', function () {
+        return axios.post('http://localhost:3001/api/middleware-endpoint', {})
+            .then(function (response) {
+                assert.strictEqual(response.status, 200, 'The response code was 200');
+            });
     });
 });
 

--- a/test/postgres/apps/test/public/js/middlewares/index.js
+++ b/test/postgres/apps/test/public/js/middlewares/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+let express = require('express');
+
+function exampleMiddleware(expressRouter) {
+    expressRouter.use(express.json({
+        limit: '10b'
+    }));
+
+    return expressRouter;
+}
+
+module.exports = {
+    exampleMiddleware: exampleMiddleware
+};

--- a/test/postgres/apps/test/public/js/routers/index.js
+++ b/test/postgres/apps/test/public/js/routers/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// intake an express router object, mutate it with custom endpoints, send it back to amorphic to register.
+function firstEndpoint(expressRouter) {
+    expressRouter.get('/test', testService.bind(this));
+
+    return expressRouter;
+}
+
+function secondEndpoint(expressRouter) {
+    expressRouter.get('/test-other-endpoint', testService.bind(this));
+
+    return expressRouter;
+}
+
+function middlewareTestEndpoint(expressRouter) {
+    expressRouter.post('/middleware-endpoint', middlewareTestService.bind(this));
+}
+
+
+function testService (_req, res) {
+    res.status(200).send('test API endpoint OK');
+}
+
+function middlewareTestService (req, res) {
+    if (!req.body) {
+        res.status(500).send('Error: no body');
+    } else {
+        res.status(200).send('test API endpoint OK');
+    }
+}
+
+module.exports = {
+    firstEndpoint: firstEndpoint,
+    secondEndpoint: secondEndpoint,
+    middlewareTestEndpoint: middlewareTestEndpoint
+};


### PR DESCRIPTION
things that were done in this MR
- Enable session based apps to add their own vanilla HTTP apis
- refactor different amorphic operating modes to be more concise (consolidate `isDaemon`,  and `serverMode` flags into one)

breaking changes w/ v 5.0.0
- daemon apps need to change from boolean `isDaemon` to serverMode: ‘daemon’
- api mode apps need to eliminate presession / postsession injects (no errors, but they just won’t get called)

follow up work after this MR:
- move server related state e.g. `serverMode` and `apiPath` config values into amorphicServer class https://massmutual.atlassian.net/browse/HL-17605