### PR TITLE
change download directory to live in os' temp folder.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 5.3.0
+* use the os' temporary directory to store downloads instead of project root directory.
 ## 5.2.0
 * Exposing expire session to all entry points that require session in the app
 * Adding interfaces / types / documentation for Amorphic App Controller

--- a/lib/utils/generateDownloadsDir.js
+++ b/lib/utils/generateDownloadsDir.js
@@ -1,30 +1,30 @@
 'use strict';
 
-let fs = require('fs');
-let path = require('path');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 /**
- * Purpose unknown
+ * creates a location for amorphic file downloads in the
+ * system's temp directory and returns a string of the path to it.
  *
- * @param {unknown} path unknown
- *
- * @returns {unknown} unknown
+ * @returns {string} - file path of downloads directory
  */
 function generateDownloadsDir() {
     // Create temporary directory for file uploads
-    let dloads = path.join(path.dirname(require.main.filename), 'download');
+    let downloadDir = path.join(os.tmpdir(), 'download');
 
-    if (!fs.existsSync(dloads)) {
-        fs.mkdirSync(dloads);
+    if (!fs.existsSync(downloadDir)) {
+        fs.mkdirSync(downloadDir);
     }
 
-    let files = fs.readdirSync(dloads);
+    let files = fs.readdirSync(downloadDir);
 
     for (let ix = 0; ix < files.length; ++ix) {
-        fs.unlinkSync(path.join(dloads, files[ix]));
+        fs.unlinkSync(path.join(downloadDir, files[ix]));
     }
 
-    return dloads;
+    return downloadDir;
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amorphic",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"dependencies": {
 		"@havenlife/persistor": "3.x",
 		"@havenlife/supertype": "3.x",

--- a/test/daemon/daemon.js
+++ b/test/daemon/daemon.js
@@ -4,6 +4,7 @@ let Bluebird = require('bluebird');
 let amorphic = require('../../dist/index.js');
 let axios = require('axios');
 let fs = require('fs');
+const os = require('os');
 let path = require('path');
 let amorphicContext = require('../../dist/lib/AmorphicContext');
 
@@ -24,7 +25,7 @@ describe('Run amorphic as a deamon', function () {
     });
 
     it('should create the download directory', function () {
-        let downloadPath = path.join(path.dirname(require.main.filename), 'download');
+        let downloadPath = path.join(os.tmpdir(), 'download');
         assert.isTrue(fs.existsSync(downloadPath), 'The download path exists');
     });
 

--- a/test/daemon_only/daemon.js
+++ b/test/daemon_only/daemon.js
@@ -4,6 +4,7 @@ let Bluebird = require('bluebird');
 let amorphic = require('../../dist/index.js');
 let axios = require('axios');
 let fs = require('fs');
+const os = require('os');
 let path = require('path');
 let amorphicContext = require('../../dist/lib/AmorphicContext');
 
@@ -24,7 +25,7 @@ describe('Run amorphic as deamon only', function() {
     });
 
     it('should create the download directory', function() {
-        let downloadPath = path.join(path.dirname(require.main.filename), 'download');
+        let downloadPath = path.join(os.tmpdir(), 'download');
         assert.isTrue(fs.existsSync(downloadPath), 'The download path exists');
     });
 

--- a/test/daemon_only_apiPath/daemon.js
+++ b/test/daemon_only_apiPath/daemon.js
@@ -4,6 +4,7 @@ let Bluebird = require('bluebird');
 let amorphic = require('../../dist/index.js');
 let axios = require('axios');
 let fs = require('fs');
+const os = require('os');
 let path = require('path');
 let amorphicContext = require('../../dist/lib/AmorphicContext');
 
@@ -24,7 +25,7 @@ describe('Run amorphic as deamon only with apiPath specified', function() {
     });
 
     it('should create the download directory', function() {
-        let downloadPath = path.join(path.dirname(require.main.filename), 'download');
+        let downloadPath = path.join(os.tmpdir(), 'download');
         assert.isTrue(fs.existsSync(downloadPath), 'The download path exists');
     });
 

--- a/test/daemon_secure/daemon_secure.js
+++ b/test/daemon_secure/daemon_secure.js
@@ -4,6 +4,7 @@ let Bluebird = require('bluebird');
 let amorphic = require('../../dist/index.js');
 let axios = require('axios');
 let fs = require('fs');
+const os = require('os');
 let path = require('path');
 let amorphicContext = require('../../dist/lib/AmorphicContext');
 
@@ -24,7 +25,7 @@ describe('Run amorphic as secure daemon', function() {
     });
 
     it('should create the download directory', function() {
-        let downloadPath = path.join(path.dirname(require.main.filename), 'download');
+        let downloadPath = path.join(os.tmpdir(), 'download');
         assert.isTrue(fs.existsSync(downloadPath), 'The download path exists');
     });
 

--- a/test/example/index.js
+++ b/test/example/index.js
@@ -3,6 +3,7 @@ let assert = require('chai').assert;
 let serverAmorphic = require('../../dist/index.js');
 let axios = require('axios');
 let fs = require('fs');
+const os = require('os');
 let path = require('path');
 let amorphicContext = require('../../dist/lib/AmorphicContext');
 
@@ -19,7 +20,7 @@ describe('Setup amorphic', function() {
     });
 
     it('make sure that the downloads directory exists', function() {
-        let downloadPath = path.join(path.dirname(require.main.filename), 'download');
+        let downloadPath = path.join(os.tmpdir(), 'download');
         assert.isTrue(fs.existsSync(downloadPath), 'The download path exists');
     });
 


### PR DESCRIPTION
the download folder is only meant to be a temporary home for items before we either persist to db or send to client, so let's put it in the best place for ephemeral things - the temp directory.